### PR TITLE
Check if getSetById exists when querying globals

### DIFF
--- a/src/Types/Query.php
+++ b/src/Types/Query.php
@@ -211,8 +211,9 @@ class Query extends Schema {
                     $setIds = \Craft::$app->globals->getAllSetIds();
 
                     foreach ($setIds as $id) {
-                        $set = \Craft::$app->globals->getSetById($id, $siteId);
-                        $sets[$set->handle] = $set;
+                        if ($set = \Craft::$app->globals->getSetById($id, $siteId)) {
+                            $sets[$set->handle] = $set;
+                        }
                     }
 
                     return $sets;


### PR DESCRIPTION
Wrapping the `$set` in an if check fixed an issue querying globals that returned an error `Trying to get property of non-object`.

[Issue #223](https://github.com/markhuot/craftql/issues/223)